### PR TITLE
Update quick-start guide with Homebrew installation

### DIFF
--- a/manuals/1.0/en/quick-start.md
+++ b/manuals/1.0/en/quick-start.md
@@ -8,21 +8,36 @@ permalink: /manuals/1.0/en/quick-start.html
 
 ## Requirement
 
-ASD requires [Docker](https://www.docker.com/products/docker-desktop).
+You need [Homebrew](https://brew.sh/ja/) or [Docker](https://www.docker.com/products/docker-desktop) to run ASD.
 
-## Install
+## Homebrew
 
-Install the asd command.
+Recommended. Do the following
+
+```shell
+brew install alps-asd/asd/asd
+````
+
+To uninstall, do the following: 
+
+```shell
+brew uninstall asd
+brew untap alps-asd/asd
+````
+
+## Docker
+
+Install the asd command with the following command.
 
 ```
-curl -L https://alps-asd.github.io/app-state-diagram/asd.sh > ./asd && chmod +x ./asd && sudo mv ./asd /usr/local/bin
+curl -L https://alps-asd.github.io/app-state-diagram/asd.sh > . /asd && chmod +x . /asd && sudo mv . /asd /usr/local/bin
 ```
 
-## Run the demo
+## Demo
 
-The following will start the development server.
+After installing either Homebrew or Docker, let's run the demo.
 
-```
+```shell
 mkdir work
 curl -L curl https://alps-asd.github.io/app-state-diagram/blog/profile.json > work/profile.json
 asd --watch ./work/profile.json

--- a/manuals/1.0/ja/quick-start.md
+++ b/manuals/1.0/ja/quick-start.md
@@ -8,9 +8,24 @@ permalink: /manuals/1.0/ja/quick-start.html
 
 ## 環境
 
-ASDの実行には[Docker](https://www.docker.com/products/docker-desktop)が必要です。
+ASDの実行には[Homebrew](https://brew.sh/ja/)または[Docker](https://www.docker.com/products/docker-desktop)が必要です。
 
-## インストール
+## Homebrew
+
+お勧めの方法です。以下のようにします。
+
+```shell
+brew install alps-asd/asd/asd
+```
+
+アンインストールするには以下のようにします。
+
+```shell
+brew uninstall asd
+brew untap alps-asd/asd
+```
+
+## Docker
 
 次のコマンドでasdコマンドをインストールします。
 
@@ -18,9 +33,9 @@ ASDの実行には[Docker](https://www.docker.com/products/docker-desktop)が必
 curl -L https://alps-asd.github.io/app-state-diagram/asd.sh > ./asd && chmod +x ./asd && sudo mv ./asd /usr/local/bin
 ```
 
-## デモの実行
+## デモ
 
-以下の操作でASDサーバーが起動します。
+HomebrewまたはDockerいずれかの方法でインストールを行った後は早速デモを実行してみましょう。
 
 ```
 mkdir work


### PR DESCRIPTION
The manuals in both English and Japanese were updated to include the installation and uninstallation instructions for ASD via Homebrew, alongside the existing Docker option. The new installation method recommendation is Homebrew, and the steps to run the demo were modified accordingly.