### PR TITLE
サイドバーに関する修正

### DIFF
--- a/_includes/manuals/1.0/footer.html
+++ b/_includes/manuals/1.0/footer.html
@@ -16,8 +16,12 @@
 <script src="//stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
 
 {% if page.category == 'Manual' %}
-    <script src="/js/generate-table-of-contents/index.min.js"></script>
     <script src="/js/copy_header_link.js"></script>
+    <script src="/js/generate-table-of-contents/index.min.js"></script>
+    <script>
+        const toc = generateTableOfContents(document.getElementById('article'));
+        document.querySelector('.side-bar-right').appendChild(toc);
+    </script>
 {% endif %}
 </body>
 </html>

--- a/_includes/manuals/1.0/footer.html
+++ b/_includes/manuals/1.0/footer.html
@@ -17,11 +17,14 @@
 
 {% if page.category == 'Manual' %}
     <script src="/js/copy_header_link.js"></script>
-    <script src="/js/generate-table-of-contents/index.min.js"></script>
-    <script>
-        const toc = generateTableOfContents(document.getElementById('article'));
-        document.querySelector('.side-bar-right').appendChild(toc);
-    </script>
+
+    {% if page.sidebar != false %}
+        <script src="/js/generate-table-of-contents/index.min.js"></script>
+        <script>
+            const toc = generateTableOfContents(document.getElementById('article'));
+            document.querySelector('.side-bar-right').appendChild(toc);
+        </script>
+    {% endif %}
 {% endif %}
 </body>
 </html>

--- a/_layouts/docs-en.html
+++ b/_layouts/docs-en.html
@@ -6,14 +6,18 @@
                 {% include manuals/1.0/en/contents.html %}
             </div>
         </div>
-        <div class="col-md-9 col-lg-8">
+
+        <div class="col-md-9 col-lg-{% if page.sidebar != false %}8{% else %}10{% endif %}">
             <article id="article" class="markdown-body">
                 {{ content }}
             </article>
         </div>
-        <div id="ArticleToc" class="col-lg-2 d-none d-lg-block">
-            <nav class="nav side-bar-right"></nav>
-        </div>
+
+        {% if page.sidebar != false %}
+            <div id="ArticleToc" class="col-lg-2 d-none d-lg-block">
+                <nav class="nav side-bar-right"></nav>
+            </div>
+        {% endif %}
     </div>
 </main>
 {% include manuals/1.0/footer.html %}

--- a/_layouts/docs-ja.html
+++ b/_layouts/docs-ja.html
@@ -6,14 +6,18 @@
                 {% include manuals/1.0/ja/contents.html %}
             </div>
         </div>
-        <div class="col-md-9 col-lg-8">
+
+        <div class="col-md-9 col-lg-{% if page.sidebar != false %}8{% else %}10{% endif %}">
             <article id="article" class="markdown-body">
                 {{ content }}
             </article>
         </div>
-        <div id="ArticleToc" class="col-lg-2 d-none d-lg-block">
-            <nav class="nav side-bar-right"></nav>
-        </div>
+
+        {% if page.sidebar != false %}
+            <div id="ArticleToc" class="col-lg-2 d-none d-lg-block">
+                <nav class="nav side-bar-right"></nav>
+            </div>
+        {% endif %}
     </div>
 </main>
 {% include manuals/1.0/footer.html %}

--- a/css/manual-skeleton.css
+++ b/css/manual-skeleton.css
@@ -20,14 +20,15 @@ img {
     max-width: 100%;
 }
 
-.markdown-body h1,
-.markdown-body h2,
-.markdown-body h3,
-.markdown-body h4,
-.markdown-body h5,
-.markdown-body h6 {
+.markdown-body :where(h1, h2, h3, h4, h5, h6) {
     margin-bottom: .5rem;
     padding: 1.5rem 0 .5rem;
+}
+
+@media (min-width: 768px) {
+    .markdown-body :where(h1, h2, h3, h4, h5, h6) {
+        scroll-margin-top: 4rem;
+    }
 }
 
 header + .container {
@@ -336,4 +337,3 @@ footer li {
     text-decoration: underline;
     text-underline-offset: .1rem;
 }
-

--- a/manuals/1.0/en/schema-org.md
+++ b/manuals/1.0/en/schema-org.md
@@ -2,6 +2,7 @@
 layout: docs-en
 title: Schema.org Terms
 category: Manual
+sidebar: false
 permalink: /manuals/1.0/en/schema-org.html
 ---
 

--- a/manuals/1.0/ja/schema-org.md
+++ b/manuals/1.0/ja/schema-org.md
@@ -2,6 +2,7 @@
 layout: docs-ja
 title: Schema.org 用語集
 category: Manual
+sidebar: false
 permalink: /manuals/1.0/ja/schema-org.html
 ---
 


### PR DESCRIPTION
- 目次が生成されない問題を修正
- アンカーリンクでHタグへ遷移した際の位置をヘッダー分調整するCSSを追加
- サイドバーの表示を制御可能にし、Schema.org 用語集ページに適応

## Sourceryによるサマリー

目次生成の修正と、アンカーリンクの挙動の調整を行います。また、サイドバーの表示を制御するメカニズムを導入し、Schema.orgの用語集ページに適用します。

バグ修正:
- 目次が生成されない問題を修正しました。

機能拡張:
- ヘッダーの高さを考慮して、アンカーリンク経由でHタグに移動する際のポジションを調整するCSSを追加しました。
- ページごとにサイドバーを無効にできるようにしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fixes table of contents generation and adjusts anchor link behavior. It also introduces a mechanism to control the sidebar display, applying it to the Schema.org glossary page.

Bug Fixes:
- Fixes an issue where the table of contents was not being generated.

Enhancements:
- Adds CSS to adjust the position when navigating to H tags via anchor links to account for the header height.
- Allows disabling the sidebar on a per-page basis.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Page layouts now adjust dynamically based on sidebar visibility. Navigation elements like the table of contents appear only when the sidebar is active, while content expands when it’s disabled.
  - Selected manual pages have been updated to hide the sidebar for a cleaner reading experience.
  
- **Style**
  - Header styling has been enhanced for improved spacing during scrolling on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->