### PR TITLE
Improve locale-aware manual links

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ permalink: /
     <p>
         Visualize Application Semantics and Affordance in REST Architecture
     </p>
-    <a class="intl btn btn-primary" id="learn" href="/manuals/1.0/ja/slide.html">
+    <a class="intl btn btn-primary" id="learn" href="/manuals/1.0/en/slide.html">
         ALPS in 1 Min &raquo;
     </a>
     <script src="/js/switch_intl.js"></script>

--- a/js/switch_intl.js
+++ b/js/switch_intl.js
@@ -1,9 +1,19 @@
-window.addEventListener('DOMContentLoaded', (event) => {
+window.addEventListener('DOMContentLoaded', () => {
+    const navigatorLanguages = window.navigator.languages;
+    const locales = (navigatorLanguages && navigatorLanguages.length)
+        ? navigatorLanguages
+        : [window.navigator.language || window.navigator.userLanguage || 'en'];
+    const prefersJapanese = locales.some((locale) => locale.toLowerCase().startsWith('ja'));
+
+    if (!prefersJapanese) {
+        return;
+    }
+
     const links = Array.from(document.getElementsByClassName('intl'));
-    const locale = (window.navigator.language || window.navigator.userLanguage || 'en').toLowerCase();
-    if (locale.startsWith('ja')) {
-        for(let i = 0; i < links.length; i++) {
-            links[i].setAttribute('href', links[i].getAttribute('href').replace('/en/', '/ja/'));
+    for (const link of links) {
+        const href = link.getAttribute('href');
+        if (href && href.includes('/en/')) {
+            link.setAttribute('href', href.replace('/en/', '/ja/'));
         }
     }
 });


### PR DESCRIPTION
## What changed

- made the locale helper prefer navigator.languages with navigator.language as fallback
- kept the manual and front-page links English by default and switched them to Japanese only for Japanese-preferring browsers

## Why

- this matches the newer locale selection behavior already used in the other manual sites
- it keeps the default link stable while making Japanese entry points more accurate for users with multiple preferred locales

## Notes

- git pull could not be completed from this environment because github.com DNS resolution failed at the time of execution
- local Jekyll build was not rerun here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed language preference detection to respect browser language settings instead of relying on previous single-locale logic.
  * Updated primary link destination to correctly reference the English documentation version.
  * Improved language switching mechanism to accurately detect user preferences and apply locale-specific link transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->