### PR TITLE
Fix documentation content issues found in content review

### DIFF
--- a/manuals/1.0/en/best_practise.md
+++ b/manuals/1.0/en/best_practise.md
@@ -12,14 +12,14 @@ permalink: /manuals/1.0/en/best_practice.html
 Application state semantic descriptors are represented in UpperCamelCase starting with a capital letter.
 
 ```json
-"descriptor": [
+{"descriptor": [
   {"id": "BlogPosting", "type": "semantic", "def": "https://schema.org/BlogPosting", "descriptor": [
     {"href": "#id"},
     {"href": "#articleBody"},
     {"href": "#dateCreated"},
     {"href": "#blog"}
   ]}
-]
+]}
 ```
 
 ## Safe State Transitions
@@ -95,10 +95,10 @@ The semantic descriptors in ALPS files are divided into three blocks in the foll
     {"id" : "Person", "type": "semantic", "descriptor":[
       {"href": "#name"},
       {"href": "#age"}
-    ]}
-    
-    {"id": "goPerson", "type": "safe", "rt": "#Person"},
-]
+    ]},
+
+    {"id": "goPerson", "type": "safe", "rt": "#Person"}
+]}
 ```
 
 ## Hierarchical Structure Outside ALPS
@@ -110,11 +110,11 @@ In ALPS, hierarchical meanings can be expressed by position.
     {"id": "name", "def": "https://schema.org/name"},
     {"id": "Product", "descriptor":[
       {"href": "#name"}
-    ]}
+    ]},
     {"id": "Person", "descriptor":[
       {"href": "#name"}
     ]}
-]
+]}
 ```
 
 * In the example above, `name` is shared between `Product/name` and `Person/name`.

--- a/manuals/1.0/en/faq.md
+++ b/manuals/1.0/en/faq.md
@@ -36,7 +36,7 @@ A. If you use an editor that supports schemas such as WebStorm, you can edit the
 
 <strong>Q. Which is better, XML or JSON</strong>?
 
-A. There is no difference in functionality. There is also no need to unify them when using multiple ALPS files. Please compare them in practice. [XML](https://github.com/koriym/app-state-diagram/blob/master/docs/blog/profile.xml) / [JSON](https://github.com/koriym/app-state-diagram/blob/master/docs/blog/profile.xml) [JSON](https://github.com/koriym/app-state-diagram/blob/master/docs/blog/profile.json)
+A. There is no difference in functionality. There is also no need to unify them when using multiple ALPS files. Please compare them in practice. [XML](https://github.com/koriym/app-state-diagram/blob/master/docs/blog/profile.xml) / [JSON](https://github.com/koriym/app-state-diagram/blob/master/docs/blog/profile.json)
 
 <strong>Q. Can it be used for APIs without links</strong>?
 
@@ -44,7 +44,7 @@ A. Yes. It cannot represent a transition diagram, but it can generate a vocabula
 
 <strong>Q. Are there any other technologies that are similar to ALPS?</strong>
 
-A. There are no direct competitors. A similar technology is [Microformat](http://www.asahi-net.or.jp/~ax2s-kmtn/internet/rec-owl-features-20040210.html).
+A. There are no direct competitors. A similar technology is [Microformat](https://microformats.org/).
 
 <strong>Q. What is the difference from IDL such as OpenAPI</strong>?
 

--- a/manuals/1.0/en/semantic-terms.md
+++ b/manuals/1.0/en/semantic-terms.md
@@ -717,17 +717,17 @@ All terms are classified into three levels based on importance and frequency of 
 
 ### Usage Notes
 
-2. **Naming Conventions**:
+1. **Naming Conventions**:
 - Use lowerCamelCase format
 - Avoid abbreviations, use complete words
 - Maintain consistent naming patterns
 
-3. **Customization**:
+2. **Customization**:
 - Can add custom terms as needed
 - Recommend using appropriate prefixes for industry-specific terms
 - Strive for unified term usage within organization
 
-4. **Interoperability**:
+3. **Interoperability**:
 - Consider compatibility with Schema.org
 - Prioritize standard terms
 - Clearly document when making custom extensions

--- a/manuals/1.0/en/tutorial_rest.md
+++ b/manuals/1.0/en/tutorial_rest.md
@@ -276,7 +276,7 @@ Choreography defines state transitions according to the types of operations. In 
    - Changes only the application state (e.g., GET).
    - Resource state is not altered.
 
-3. `unsafe`
+2. `unsafe`
    - Creates a new resource state.
    - May have different outcomes each time it is executed.
 
@@ -284,7 +284,7 @@ Choreography defines state transitions according to the types of operations. In 
    - Updates or deletes the resource state.
    - Produces the same outcome no matter how many times it is executed.
 
-ALPS operations distinguish between resource changes that have a different result each time they are performed, i.e., non-idempotent operations, such as add operations, and those that have a different result each time they are performed, i.e., idempotent operations, such as change or delete operations, which do not change the result no matter how many times they are repeated.
+ALPS operations distinguish between resource changes that have a different result each time they are performed, i.e., non-idempotent operations, such as add operations, and those that produce the same result no matter how many times they are repeated, i.e., idempotent operations, such as change or delete operations.
 
 ### Defining the Transition to View an Article
 
@@ -307,7 +307,7 @@ In XML:
         <descriptor href="#articleBody"/>
     </descriptor>
     <descriptor id="goBlogPosting" type="safe" rt="#BlogPosting" title="View Blog Post">
-        <descriptor href="#dateCreated"/>
+        <descriptor href="#id"/>
     </descriptor>
 </alps>
 ```
@@ -326,7 +326,7 @@ In JSON:
                {"href": "#articleBody"}
             ]},
             {"id": "goBlogPosting", "type": "safe", "rt": "#BlogPosting", "title": "View Blog Post", "descriptor": [
-               {"href": "#dateCreated"}
+               {"href": "#id"}
             ]}
         ]
     }
@@ -348,7 +348,7 @@ Important elements of this definition:
    - Indicates a transition to `#BlogPosting`.
 
 3. Information Needed for the Transition
-   - Specified by `descriptor href="#dateCreated"`.
+   - Specified by `descriptor href="#id"`.
    - Represents the information needed to identify the post.
 
 In the preview screen:

--- a/manuals/1.0/ja/best_practise.md
+++ b/manuals/1.0/ja/best_practise.md
@@ -13,14 +13,14 @@ permalink: /manuals/1.0/ja/best_practice.html
 アプリケーション状態のセマンティックディスクリプタは大文字始まりのアッパーキャメルケースで表されます。
 
 ```json
-"descriptor": [
+{"descriptor": [
   {"id": "BlogPosting", "type": "semantic", "def": "https://schema.org/BlogPosting", "descriptor": [
     {"href": "#id"},
     {"href": "#articleBody"},
     {"href": "#dateCreated"},
     {"href": "#blog"}
   ]}
-]
+]}
 ```
 
 ## 安全な状態遷移
@@ -90,17 +90,17 @@ ALPSファイルのセマンティクディスクリプターは以下の順の3
 3. 状態遷移のセマンティックディスクリプタ群(コレオグラフィー)
 
 ```json
-"descriptor" : [
+{"descriptor" : [
     {"id" : "name", "type" : "semantic", "def": "http://schema.org/identifier"},
     {"id" : "age", "type" : "semantic", "def": "http://schema.org/title"},
 
     {"id" : "Person", "type": "semantic", "descriptor":[
       {"href": "#name"},
       {"href": "#age"}
-    ]}
-    
-    {"id": "goPerson", "type": "safe", "rt": "#Person"},
-]
+    ]},
+
+    {"id": "goPerson", "type": "safe", "rt": "#Person"}
+]}
 ```
 
 ## ALPSの外にある階層構造
@@ -108,15 +108,15 @@ ALPSファイルのセマンティクディスクリプターは以下の順の3
 ALPSでは、階層的な意味をポジションで表現できます。
 
 ```json
-"descriptor": [
+{"descriptor": [
     {"id": "name", "def": "https://schema.org/name"},
     {"id": "Product", "descriptor":[
       {"href": "#name"}
-    ]}
+    ]},
     {"id": "Person", "descriptor":[
       {"href": "#name"}
     ]}
-]
+]}
 ```
 
 * 上記の例では、`name`は、`Product/name`と`Person/name`で共有されています。

--- a/manuals/1.0/ja/faq.md
+++ b/manuals/1.0/ja/faq.md
@@ -44,7 +44,7 @@ A. 遷移図は表せませんが、ボキャブラリや情報の性質を表�
 
 <strong>Q. ALPSと同様の技術は他にありますか</strong>
 
-A. 直接の競合技術はありません。近い技術に[Microformat](http://www.asahi-net.or.jp/~ax2s-kmtn/internet/rec-owl-features-20040210.html)があります。
+A. 直接の競合技術はありません。近い技術に[Microformat](https://microformats.org/)があります。
 
 <strong>Q. OpenAPIなどのIDLと何が違いますか</strong>
 

--- a/manuals/1.0/ja/reference.md
+++ b/manuals/1.0/ja/reference.md
@@ -122,7 +122,7 @@ descriptorは以下の子要素を持つことができます：
 * **id**: 一意の識別子（hrefと排他）
   - descriptorを一意に識別する文字列
   - 同一文書内で重複不可
-  - URL安全な文字のみ使用可能（[RFC1738](https://www.rfc-editor.org/rfc/rfc1738)に準拠）
+  - URL安全な文字のみ使用可能（[RFC3986](https://www.rfc-editor.org/rfc/rfc3986)に準拠）
 
 * **href**: 参照先（idと排他）
   - 他のdescriptorを参照するための識別子

--- a/manuals/1.0/ja/semantic-terms.md
+++ b/manuals/1.0/ja/semantic-terms.md
@@ -429,8 +429,6 @@ permalink: /manuals/1.0/ja/semantic-terms.html
 | itemReviewed | 🟡 | レビュー対象 |
 | recommendationStrength | ⚪ | 推奨強度 |
 | associatedReview | ⚪ | 関連レビュー |
-| reviewBody | ⚪ | レビュー本文 |
-| reviewRating | ⚪ | レビュー評価 |
 | abridged | ⚪ | 要約版 |
 
 ### 教育・学習
@@ -573,8 +571,6 @@ permalink: /manuals/1.0/ja/semantic-terms.html
 | hasDigitalDocumentPermission | 🟡 | デジタル文書権限 |
 | permissionAssertion | ⚪ | 権限アサーション |
 | securityScreening | ⚪ | セキュリティスクリーニング |
-| accessibilityControl | ⚪ | アクセシビリティ制御 |
-| accessModeSufficient | ⚪ | 十分なアクセスモード |
 
 ### ワークフロー・プロセス
 
@@ -723,17 +719,17 @@ permalink: /manuals/1.0/ja/semantic-terms.html
 ### 使用上の注意
 
 
-2. **命名規則**:
+1. **命名規則**:
   - lowerCamelCase形式を使用
   - 略語は避け、完全な単語を使用
   - 一貫性のある命名パターンを維持
 
-3. **カスタマイズ**:
+2. **カスタマイズ**:
   - 必要に応じて独自の用語を追加可能
   - 業界固有の用語は適切なプレフィックスを付けることを推奨
   - 組織内で統一した用語の使用を心がける
 
-4. **相互運用性**:
+3. **相互運用性**:
   - Schema.orgとの互換性を意識
   - 標準的な用語を優先的に使用
   - 独自拡張する場合は明確な文書化を行う

--- a/manuals/1.0/ja/tutorial_rest.md
+++ b/manuals/1.0/ja/tutorial_rest.md
@@ -308,7 +308,7 @@ XMLの場合：
         <descriptor href="#articleBody"/>
     </descriptor>
     <descriptor id="goBlogPosting" type="safe" rt="#BlogPosting" title="ブログ記事を見る">
-        <descriptor href="#dateCreated"/>
+        <descriptor href="#id"/>
     </descriptor>
 </alps>
 ```
@@ -327,7 +327,7 @@ JSONの場合：
                {"href": "#articleBody"}
             ]},
             {"id": "goBlogPosting", "type": "safe", "rt": "#BlogPosting", "title": "ブログ記事を見る", "descriptor": [
-               {"href": "#dateCreated"}
+               {"href": "#id"}
             ]}
         ]
     }
@@ -350,7 +350,7 @@ JSONの場合：
    - `#BlogPosting`への遷移を示します
 
 3. 遷移に必要な情報
-   - `descriptor href="#dateCreated"`で指定します
+   - `descriptor href="#id"`で指定します
    - 記事を特定するために必要な情報です
 
 プレビュー画面では：
@@ -378,7 +378,7 @@ JSONの場合：
 ここで、閲覧（safe）と作成（unsafe）の違いに注目してください：
 
 1. 必要な情報
-   - 閲覧：dateCreated（記事を特定）
+   - 閲覧：id（記事を特定）
    - 作成：articleBody（記事の内容）
 
 2. 状態の変化
@@ -388,6 +388,28 @@ JSONの場合：
 3. 実行結果
    - 閲覧：何度実行しても同じ
    - 作成：実行ごとに新しい記事が作られる
+
+### 記事を更新する遷移を定義する
+
+次に、ブログ記事を更新する操作（idempotent）を定義します：
+
+XMLの場合：
+```xml
+<descriptor id="doUpdateBlogPosting" type="idempotent" rt="#BlogPosting" title="ブログ記事を更新する">
+    <descriptor href="#articleBody"/>
+</descriptor>
+```
+
+JSONの場合：
+```json
+{"id": "doUpdateBlogPosting", "type": "idempotent", "rt": "#BlogPosting", "title": "ブログ記事を更新する", "descriptor": [
+    {"href": "#articleBody"}
+]}
+```
+
+この定義で重要な要素：
+1. `type`属性に`idempotent`を指定し、繰り返し実行しても結果が変わらない更新操作であることを示します
+2. 更新に必要な情報として`articleBody`を指定します
 
 次のステップでは、これらの遷移をブログ全体の構造に組み込んでいきます。
 
@@ -413,15 +435,19 @@ XMLの場合：
         <descriptor href="#articleBody"/>
     </descriptor>
     <descriptor id="goBlogPosting" type="safe" rt="#BlogPosting" title="ブログ記事を見る">
-        <descriptor href="#dateCreated"/>
+        <descriptor href="#id"/>
     </descriptor>
     <descriptor id="doCreateBlogPosting" type="unsafe" rt="#BlogPosting" title="ブログ記事を作成する">
+        <descriptor href="#articleBody"/>
+    </descriptor>
+    <descriptor id="doUpdateBlogPosting" type="idempotent" rt="#BlogPosting" title="ブログ記事を更新する">
         <descriptor href="#articleBody"/>
     </descriptor>
     <descriptor id="Blog" title="ブログ">
         <descriptor href="#BlogPosting"/>
         <descriptor href="#goBlogPosting"/>
         <descriptor href="#doCreateBlogPosting"/>
+        <descriptor href="#doUpdateBlogPosting"/>
     </descriptor>
 </alps>
 ```
@@ -440,12 +466,14 @@ JSONの場合：
                 {"href": "#dateCreated"},
                 {"href": "#articleBody"}
             ]},
-            {"id": "goBlogPosting", "type": "safe", "rt": "#BlogPosting", "title": "ブログ記事を見る", "descriptor": [{"href": "#dateCreated"}]},
+            {"id": "goBlogPosting", "type": "safe", "rt": "#BlogPosting", "title": "ブログ記事を見る", "descriptor": [{"href": "#id"}]},
             {"id": "doCreateBlogPosting", "type": "unsafe", "rt": "#BlogPosting", "title": "ブログ記事を作成する", "descriptor": [{"href": "#articleBody"}]},
+            {"id": "doUpdateBlogPosting", "type": "idempotent", "rt": "#BlogPosting", "title": "ブログ記事を更新する", "descriptor": [{"href": "#articleBody"}]},
             {"id": "Blog", "title": "ブログ", "descriptor": [
                 {"href": "#BlogPosting"},
                 {"href": "#goBlogPosting"},
-                {"href": "#doCreateBlogPosting"}
+                {"href": "#doCreateBlogPosting"},
+                {"href": "#doUpdateBlogPosting"}
             ]}
         ]
     }
@@ -462,12 +490,13 @@ JSONの場合：
 2. 状態遷移
    - goBlogPosting：記事の閲覧操作（safe）
    - doCreateBlogPosting：記事の作成操作（unsafe）
+   - doUpdateBlogPosting：記事の更新操作（idempotent）
 
 プレビュー画面では：
 1. 状態遷移図
    - Blog、BlogPostingが状態として表示されます
    - 状態間の遷移が矢印として表示されます
-   - safe遷移とunsafe遷移が異なるスタイルで表現されます
+   - safe遷移、unsafe遷移、idempotent遷移が異なるスタイルで表現されます
 
 2. ボキャブラリリスト
    - 定義した全ての要素が階層的に表示されます
@@ -514,19 +543,19 @@ JSONの場合：
 XMLの場合：
 ```xml
 <descriptor id="goBlogPosting" type="safe" rt="#BlogPosting" title="ブログ記事を見る">
-    <descriptor href="#dateCreated"/>
+    <descriptor href="#id"/>
 </descriptor>
 ```
 
 JSONの場合：
 ```json
 {"id": "goBlogPosting", "type": "safe", "rt": "#BlogPosting", "title": "ブログ記事を見る", 
- "descriptor": [{"href": "#dateCreated"}]}
+ "descriptor": [{"href": "#id"}]}
 ```
 - 操作の種類を定義します
 - safe：閲覧操作（prefixは`go`）
-- unsafe：作成操作（prefixは`doCreate`）
-- idempotent：更新・削除操作（prefixは`update`/`delete`）
+- unsafe：作成操作（prefixは`do`、例: `doCreate`）
+- idempotent：更新・削除操作（prefixは`do`、例: `doUpdate`/`doDelete`）
 
 ### リンク関係の指定
 
@@ -580,6 +609,7 @@ XMLの場合：
     <descriptor href="#BlogPosting"/>
     <descriptor href="#goBlogPosting"/>
     <descriptor href="#doCreateBlogPosting"/>
+    <descriptor href="#doUpdateBlogPosting"/>
 </descriptor>
 ```
 
@@ -588,10 +618,11 @@ JSONの場合：
 {"id": "Blog", "title": "ブログ", "descriptor": [
     {"href": "#BlogPosting"},
     {"href": "#goBlogPosting"},
-    {"href": "#doCreateBlogPosting"}
+    {"href": "#doCreateBlogPosting"},
+    {"href": "#doUpdateBlogPosting"}
 ]}
 ```
-- 情報構造と操作を組み合わせて完全な定義を作成します
+- 情報構造と閲覧・作成・更新操作を組み合わせて完全な定義を作成します
 - リソースの全体構造を表現します
 
 ### 要素の分類とグループ化
@@ -605,6 +636,7 @@ XMLの場合：
     <descriptor href="#articleBody" tag="content"/>
     <descriptor href="#goBlogPosting" tag="navigation"/>
     <descriptor href="#doCreateBlogPosting" tag="action"/>
+    <descriptor href="#doUpdateBlogPosting" tag="action"/>
 </descriptor>
 ```
 
@@ -617,7 +649,8 @@ JSONの場合：
         {"href": "#dateCreated", "tag": "metadata"},
         {"href": "#articleBody", "tag": "content"},
         {"href": "#goBlogPosting", "tag": "navigation"},
-        {"href": "#doCreateBlogPosting", "tag": "action"}
+        {"href": "#doCreateBlogPosting", "tag": "action"},
+        {"href": "#doUpdateBlogPosting", "tag": "action"}
     ]
 }
 ```


### PR DESCRIPTION
## Summary

Deterministic content fixes found during an independent content-quality review of the ALPS/ASD manuals. Only changes with an objectively correct fix are included; design-judgment items are tracked separately as issues (#53–#56).

## Changes

- **best_practise (en/ja):** make JSON examples valid (missing commas, trailing commas, missing object wrappers) — every fenced `json` block now parses
- **tutorial_rest (en):** fix the self-contradictory idempotent description; renumber the operation list to 1, 2, 3
- **tutorial_rest (ja):** use the `do` prefix convention for unsafe/idempotent
- **tutorial_rest (en/ja):** add the missing `doUpdateBlogPosting` example and unify the `goBlogPosting` identifier to `#id`
- **faq (en):** fix a duplicate/mislabeled JSON link
- **faq (en/ja):** repoint the Microformat link to microformats.org (was pointing to an OWL document)
- **semantic-terms (en/ja):** renumber the "Usage Notes" list to start at 1
- **semantic-terms (ja):** remove duplicate terms that had conflicting importance levels
- **reference (ja):** cite RFC3986 instead of the obsoleted RFC1738

## Verification

- All `json` fenced blocks in the changed files parse successfully
- `goBlogPosting` no longer references `#dateCreated`
- English and Japanese manuals aligned on the above points

Closes #57
Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected JSON descriptor structure examples in best practices guide
  * Fixed reference links in FAQ (XML/JSON profiles and Microformat resources)
  * Enhanced REST tutorial with additional operation examples and clarifications
  * Improved semantic terms documentation with better formatting and organization
  * Updated documentation across English and Japanese versions for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->