### PR TITLE
Ignore local artifacts and drafts; remove leaked-metadata archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,20 @@ watch
 llms-full.txt
 manuals/1.0/en/1page.md
 manuals/1.0/ja/1page.md
+
+# OS / editor artifacts
+.DS_Store
+.idea/
+
+# Local archives and drafts (not part of the published site)
+*.zip
+spilke.md
+manuals/1.0/ja/マニュアル抜粋
+
+# Platform-specific Bundler lockfile (regenerated locally; not tracked)
+Gemfile.lock
+
+# Local tooling / agent config
+.claude/
+AGENTS.md
+CLAUDE.md


### PR DESCRIPTION
## Summary

Repository-hygiene change prompted by a review that flagged untracked local files which would be exposed if committed. `_config.yml` has no `exclude:`, so Jekyll publishes any file at the repo root — committing these would leak them onto the published site.

## Changes

- Remove `manuals.zip` — a backup archive containing `.idea/workspace.xml` (local IDE/account metadata), `.DS_Store`, and `__MACOSX` entries.
- `.gitignore` now excludes:
  - `*.zip` — local archives
  - `spilke.md`, `manuals/1.0/ja/マニュアル抜粋` — local drafts with generation artifacts
  - `Gemfile.lock` — resolved only for `arm64-darwin`; would break Linux/Docker/CI installs in frozen mode (this repo has never tracked it)
  - `.DS_Store`, `.idea/`, `.claude/`, `AGENTS.md`, `CLAUDE.md` — OS/editor/agent tooling state

Drafts are kept on disk; only their tracking/publishing is prevented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository ignore rules to exclude generated site output, temporary watch artifacts, OS/editor clutter, local drafts/archives, locally regenerated dependency lockfiles, and local tooling/agent configuration files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->