### PR TITLE
Add schema.org term cross references

### DIFF
--- a/_includes/html/property-meta.html
+++ b/_includes/html/property-meta.html
@@ -6,7 +6,11 @@
             {% assign domains = property.domainIncludes | split: ", " %}
             {% for domain in domains %}
             {% assign domain_name = domain | replace: "https://schema.org/", "" %}
+            {% if domain contains "https://schema.org/" %}
+            <a href="#schema-type-{{ domain_name }}" class="meta-tag domain-tag schema-xref-link">{{ domain_name }}</a>
+            {% else %}
             <span class="meta-tag domain-tag">{{ domain_name }}</span>
+            {% endif %}
             {% endfor %}
         </div>
     </div>
@@ -19,7 +23,11 @@
             {% assign ranges = property.rangeIncludes | split: ", " %}
             {% for range in ranges %}
             {% assign range_name = range | replace: "https://schema.org/", "" %}
+            {% if range contains "https://schema.org/" %}
+            <a href="#schema-type-{{ range_name }}" class="meta-tag range-tag schema-xref-link">{{ range_name }}</a>
+            {% else %}
             <span class="meta-tag range-tag">{{ range_name }}</span>
+            {% endif %}
             {% endfor %}
         </div>
     </div>
@@ -30,7 +38,11 @@
         <span class="meta-label">SubPropertyOf:</span>
         <div class="meta-values">
             {% assign subprop = property.subPropertyOf | replace: "https://schema.org/", "" %}
+            {% if property.subPropertyOf contains "https://schema.org/" %}
+            <a href="#schema-property-{{ subprop }}" class="meta-tag subprop-tag schema-xref-link">{{ subprop }}</a>
+            {% else %}
             <span class="meta-tag subprop-tag">{{ subprop }}</span>
+            {% endif %}
         </div>
     </div>
     {% endif %}
@@ -40,8 +52,14 @@
         <span class="meta-label">InverseOf:</span>
         <div class="meta-values">
             {% assign inverse = property.inverseOf | replace: "https://schema.org/", "" %}
+            {% if property.inverseOf contains "https://schema.org/" %}
+            <a href="#schema-property-{{ inverse }}" class="meta-tag inverse-tag schema-xref-link">{{ inverse }}</a>
+            {% else %}
             <span class="meta-tag inverse-tag">{{ inverse }}</span>
+            {% endif %}
         </div>
     </div>
     {% endif %}
+
+    <div class="meta-item schema-xref-container" hidden></div>
 </td>

--- a/_includes/html/type-meta.html
+++ b/_includes/html/type-meta.html
@@ -6,7 +6,11 @@
             {% assign subtypes = type.subTypeOf | split: ", " %}
             {% for subtype in subtypes %}
             {% assign subtype_name = subtype | replace: "https://schema.org/", "" %}
+            {% if subtype contains "https://schema.org/" %}
+            <a href="#schema-type-{{ subtype_name }}" class="meta-tag subtype-tag schema-xref-link">{{ subtype_name }}</a>
+            {% else %}
             <span class="meta-tag subtype-tag">{{ subtype_name }}</span>
+            {% endif %}
             {% endfor %}
         </div>
     </div>
@@ -19,7 +23,11 @@
             {% assign props = type.properties | split: ", " %}
             {% for prop in props | limit:5 %}
             {% assign prop_name = prop | replace: "https://schema.org/", "" %}
+            {% if prop contains "https://schema.org/" %}
+            <a href="#schema-property-{{ prop_name }}" class="meta-tag properties-tag schema-xref-link">{{ prop_name }}</a>
+            {% else %}
             <span class="meta-tag properties-tag">{{ prop_name }}</span>
+            {% endif %}
             {% endfor %}
             {% if props.size > 5 %}
             <span class="meta-tag more-tag">+{{ props.size | minus: 5 }}個</span>
@@ -35,9 +43,15 @@
             {% assign subtypes_list = type.subTypes | split: ", " %}
             {% for subtype in subtypes_list %}
             {% assign subtype_name = subtype | replace: "https://schema.org/", "" %}
+            {% if subtype contains "https://schema.org/" %}
+            <a href="#schema-type-{{ subtype_name }}" class="meta-tag subtypes-tag schema-xref-link">{{ subtype_name }}</a>
+            {% else %}
             <span class="meta-tag subtypes-tag">{{ subtype_name }}</span>
+            {% endif %}
             {% endfor %}
         </div>
     </div>
     {% endif %}
+
+    <div class="meta-item schema-xref-container" hidden></div>
 </td>

--- a/css/schema-styles.css
+++ b/css/schema-styles.css
@@ -142,10 +142,27 @@ tbody tr:hover {
     max-width: 100%;
 }
 
+.schema-xref-values-inline {
+    align-items: center;
+}
+
+.schema-xref-values-inline .schema-xref-details {
+    display: inline-block;
+}
+
+.schema-xref-values-inline .schema-xref-details[open] {
+    display: block;
+    flex-basis: 100%;
+}
+
 .schema-xref-details summary {
+    background-color: #f5f5f5;
+    border-radius: 3px;
     color: #555;
     cursor: pointer;
+    display: inline-block;
     list-style-position: outside;
+    padding: 1px 8px;
 }
 
 .schema-xref-count {

--- a/css/schema-styles.css
+++ b/css/schema-styles.css
@@ -122,6 +122,83 @@ tbody tr:hover {
     color: #616161;
 }
 
+/* クロスリファレンス */
+.schema-xref-link,
+.schema-xref-source {
+    text-decoration: none;
+}
+
+.schema-xref-link:hover,
+.schema-xref-source:hover {
+    text-decoration: underline;
+}
+
+.schema-xref-container {
+    align-items: flex-start;
+    margin-top: 6px;
+}
+
+.schema-xref-details {
+    max-width: 100%;
+}
+
+.schema-xref-details summary {
+    color: #555;
+    cursor: pointer;
+    list-style-position: outside;
+}
+
+.schema-xref-count {
+    font-weight: 600;
+}
+
+.schema-xref-content {
+    margin-top: 6px;
+}
+
+.schema-xref-group {
+    margin-bottom: 8px;
+}
+
+.schema-xref-group-label {
+    color: #666;
+    font-size: 12px;
+    margin-bottom: 3px;
+}
+
+.schema-xref-values {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.schema-xref-property-tag {
+    background-color: #f1f8e9;
+    color: #33691e;
+}
+
+.schema-xref-type-tag {
+    background-color: #e8f0fe;
+    color: #174ea6;
+}
+
+tr:target {
+    background-color: #fffde7;
+}
+
+.schema-target-flash {
+    animation: schema-target-flash 1.6s ease-out;
+}
+
+@keyframes schema-target-flash {
+    0% {
+        background-color: #fff59d;
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
 /* 検索関連のスタイル */
 .schema-search {
     margin-bottom: 20px;

--- a/css/schema-styles.css
+++ b/css/schema-styles.css
@@ -1,5 +1,9 @@
 /* schema-styles.css */
 
+html {
+    scroll-behavior: smooth;
+}
+
 table {
     width: 100%;
     table-layout: auto; /* 内容に合わせて列幅を調整 */

--- a/js/schema-xref.js
+++ b/js/schema-xref.js
@@ -4,7 +4,7 @@
     const I18N = {
         en: {
             usedBy: 'Used by',
-            references: 'references',
+            more: 'more',
             relationLabels: {
                 typeProperty: 'Types using this property',
                 domain: 'Properties with this domain',
@@ -16,7 +16,7 @@
         },
         ja: {
             usedBy: '参照元',
-            references: '件を表示',
+            more: '件を展開',
             relationLabels: {
                 typeProperty: 'このプロパティを使うタイプ',
                 domain: 'Domainに指定しているプロパティ',
@@ -36,6 +36,7 @@
         'inverseOf',
         'subTypeOf'
     ];
+    const PREVIEW_LIMIT = 5;
 
     function onReady(callback) {
         if (document.readyState === 'loading') {
@@ -178,6 +179,22 @@
         });
     }
 
+    function orderReferences(refs) {
+        const groups = groupByRelation(refs);
+
+        return RELATION_ORDER.flatMap((relation) => (
+            (groups.get(relation) || [])
+                .slice()
+                .sort((a, b) => a.sourceTerm.localeCompare(b.sourceTerm))
+        ));
+    }
+
+    function renderReferencePreview(container, refs) {
+        orderReferences(refs)
+            .slice(0, PREVIEW_LIMIT)
+            .forEach((ref) => container.appendChild(createSourceLink(ref)));
+    }
+
     function installReferenceDetails(row, refs, labels) {
         const container = row.querySelector('.schema-xref-container');
         if (!container || refs.length === 0) {
@@ -191,13 +208,21 @@
         label.textContent = `${labels.usedBy}:`;
 
         const values = document.createElement('div');
-        values.className = 'meta-values';
+        values.className = 'meta-values schema-xref-values-inline';
+
+        renderReferencePreview(values, refs);
+
+        if (refs.length <= PREVIEW_LIMIT) {
+            container.appendChild(label);
+            container.appendChild(values);
+            return;
+        }
 
         const details = document.createElement('details');
         details.className = 'schema-xref-details';
 
         const summary = document.createElement('summary');
-        summary.innerHTML = `<span class="schema-xref-count">${refs.length}</span> ${labels.references}`;
+        summary.innerHTML = `<span class="schema-xref-count">+${refs.length - PREVIEW_LIMIT}</span> ${labels.more}`;
         details.appendChild(summary);
 
         const content = document.createElement('div');

--- a/js/schema-xref.js
+++ b/js/schema-xref.js
@@ -1,0 +1,260 @@
+(function () {
+    'use strict';
+
+    const I18N = {
+        en: {
+            usedBy: 'Used by',
+            references: 'references',
+            relationLabels: {
+                typeProperty: 'Types using this property',
+                domain: 'Properties with this domain',
+                range: 'Properties with this range',
+                subPropertyOf: 'Subproperties',
+                inverseOf: 'Inverse properties',
+                subTypeOf: 'Subtypes'
+            }
+        },
+        ja: {
+            usedBy: '参照元',
+            references: '件を表示',
+            relationLabels: {
+                typeProperty: 'このプロパティを使うタイプ',
+                domain: 'Domainに指定しているプロパティ',
+                range: 'Rangeに指定しているプロパティ',
+                subPropertyOf: 'サブプロパティ',
+                inverseOf: 'InverseOfで参照するプロパティ',
+                subTypeOf: 'サブタイプ'
+            }
+        }
+    };
+
+    const RELATION_ORDER = [
+        'typeProperty',
+        'domain',
+        'range',
+        'subPropertyOf',
+        'inverseOf',
+        'subTypeOf'
+    ];
+
+    function onReady(callback) {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', callback);
+            return;
+        }
+
+        callback();
+    }
+
+    function parseList(value) {
+        if (!value) {
+            return [];
+        }
+
+        return value
+            .split(',')
+            .map((item) => item.trim().replace(/^https?:\/\/schema\.org\//, ''))
+            .filter(Boolean);
+    }
+
+    function keyFor(kind, term) {
+        return `${kind}:${term}`;
+    }
+
+    function anchorFor(kind, term) {
+        return `#schema-${kind}-${term}`;
+    }
+
+    function addReference(references, rowIndex, targetKind, targetTerm, sourceKind, sourceTerm, relation) {
+        if (!targetTerm || targetTerm.includes('://')) {
+            return;
+        }
+
+        const targetKey = keyFor(targetKind, targetTerm);
+        const sourceKey = keyFor(sourceKind, sourceTerm);
+
+        if (!rowIndex.has(targetKey) || !rowIndex.has(sourceKey)) {
+            return;
+        }
+
+        const refs = references.get(targetKey) || [];
+        const exists = refs.some((ref) => (
+            ref.sourceKind === sourceKind &&
+            ref.sourceTerm === sourceTerm &&
+            ref.relation === relation
+        ));
+
+        if (!exists) {
+            refs.push({ sourceKind, sourceTerm, relation });
+            references.set(targetKey, refs);
+        }
+    }
+
+    function buildReferences(rows, rowIndex) {
+        const references = new Map();
+
+        rows.forEach((row) => {
+            const sourceKind = row.dataset.schemaKind;
+            const sourceTerm = row.dataset.schemaTerm;
+
+            if (sourceKind === 'property') {
+                parseList(row.dataset.domainIncludes).forEach((term) => {
+                    addReference(references, rowIndex, 'type', term, sourceKind, sourceTerm, 'domain');
+                });
+
+                parseList(row.dataset.rangeIncludes).forEach((term) => {
+                    addReference(references, rowIndex, 'type', term, sourceKind, sourceTerm, 'range');
+                });
+
+                parseList(row.dataset.subPropertyOf).forEach((term) => {
+                    addReference(references, rowIndex, 'property', term, sourceKind, sourceTerm, 'subPropertyOf');
+                });
+
+                parseList(row.dataset.inverseOf).forEach((term) => {
+                    addReference(references, rowIndex, 'property', term, sourceKind, sourceTerm, 'inverseOf');
+                });
+            }
+
+            if (sourceKind === 'type') {
+                parseList(row.dataset.subTypeOf).forEach((term) => {
+                    addReference(references, rowIndex, 'type', term, sourceKind, sourceTerm, 'subTypeOf');
+                });
+
+                parseList(row.dataset.properties).forEach((term) => {
+                    addReference(references, rowIndex, 'property', term, sourceKind, sourceTerm, 'typeProperty');
+                });
+            }
+        });
+
+        return references;
+    }
+
+    function groupByRelation(refs) {
+        return refs.reduce((groups, ref) => {
+            if (!groups.has(ref.relation)) {
+                groups.set(ref.relation, []);
+            }
+
+            groups.get(ref.relation).push(ref);
+            return groups;
+        }, new Map());
+    }
+
+    function createSourceLink(ref) {
+        const link = document.createElement('a');
+        link.href = anchorFor(ref.sourceKind, ref.sourceTerm);
+        link.className = `meta-tag schema-xref-source schema-xref-${ref.sourceKind}-tag`;
+        link.textContent = ref.sourceTerm;
+        return link;
+    }
+
+    function renderReferenceList(content, refs, labels) {
+        const groups = groupByRelation(refs);
+
+        RELATION_ORDER.forEach((relation) => {
+            const groupRefs = groups.get(relation);
+            if (!groupRefs || groupRefs.length === 0) {
+                return;
+            }
+
+            const group = document.createElement('div');
+            group.className = 'schema-xref-group';
+
+            const label = document.createElement('div');
+            label.className = 'schema-xref-group-label';
+            label.textContent = `${labels.relationLabels[relation]} (${groupRefs.length})`;
+            group.appendChild(label);
+
+            const values = document.createElement('div');
+            values.className = 'schema-xref-values';
+
+            groupRefs
+                .slice()
+                .sort((a, b) => a.sourceTerm.localeCompare(b.sourceTerm))
+                .forEach((ref) => values.appendChild(createSourceLink(ref)));
+
+            group.appendChild(values);
+            content.appendChild(group);
+        });
+    }
+
+    function installReferenceDetails(row, refs, labels) {
+        const container = row.querySelector('.schema-xref-container');
+        if (!container || refs.length === 0) {
+            return;
+        }
+
+        container.hidden = false;
+
+        const label = document.createElement('span');
+        label.className = 'meta-label';
+        label.textContent = `${labels.usedBy}:`;
+
+        const values = document.createElement('div');
+        values.className = 'meta-values';
+
+        const details = document.createElement('details');
+        details.className = 'schema-xref-details';
+
+        const summary = document.createElement('summary');
+        summary.innerHTML = `<span class="schema-xref-count">${refs.length}</span> ${labels.references}`;
+        details.appendChild(summary);
+
+        const content = document.createElement('div');
+        content.className = 'schema-xref-content';
+        details.appendChild(content);
+
+        details.addEventListener('toggle', () => {
+            if (!details.open || details.dataset.rendered === 'true') {
+                return;
+            }
+
+            renderReferenceList(content, refs, labels);
+            details.dataset.rendered = 'true';
+        });
+
+        values.appendChild(details);
+        container.appendChild(label);
+        container.appendChild(values);
+    }
+
+    function flashLinkedRow(event) {
+        const link = event.target.closest('.schema-xref-link, .schema-xref-source');
+        if (!link || !link.hash) {
+            return;
+        }
+
+        const target = document.getElementById(decodeURIComponent(link.hash.slice(1)));
+        if (!target) {
+            return;
+        }
+
+        const searchInput = document.getElementById('schema-combined-search');
+        if (target.classList.contains('hidden-row') && searchInput && searchInput.value) {
+            searchInput.value = '';
+            searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+
+        target.classList.remove('schema-target-flash');
+        window.setTimeout(() => target.classList.add('schema-target-flash'), 0);
+        window.setTimeout(() => target.classList.remove('schema-target-flash'), 1600);
+    }
+
+    onReady(() => {
+        const rows = Array.from(document.querySelectorAll('tr[data-schema-term][data-schema-kind]'));
+        if (rows.length === 0) {
+            return;
+        }
+
+        const labels = window.location.pathname.includes('/ja/') ? I18N.ja : I18N.en;
+        const rowIndex = new Map(rows.map((row) => [keyFor(row.dataset.schemaKind, row.dataset.schemaTerm), row]));
+        const references = buildReferences(rows, rowIndex);
+
+        rows.forEach((row) => {
+            const rowKey = keyFor(row.dataset.schemaKind, row.dataset.schemaTerm);
+            installReferenceDetails(row, references.get(rowKey) || [], labels);
+        });
+
+        document.addEventListener('click', flashLinkedRow);
+    });
+}());

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2285,6 +2285,7 @@ The Japanese manual includes a translated copy of the draft. Use the official IE
 <!-- Source: manuals/1.0/en/schema-org.md -->
 
 <link rel="stylesheet" href="{{ '/css/schema-styles.css' | relative_url }}">
+<script src="{{ '/js/schema-xref.js' | relative_url }}" defer></script>
 
 
 # Schema.org Terms
@@ -2303,7 +2304,13 @@ The Japanese manual includes a translated copy of the draft. Use the official IE
   </thead>
   <tbody>
     {% for property in site.data.schema_properties %}
-      <tr>
+      <tr id="schema-property-{{ property.label }}"
+          data-schema-term="{{ property.label | escape }}"
+          data-schema-kind="property"
+          data-domain-includes="{{ property.domainIncludes | replace: 'https://schema.org/', '' | escape }}"
+          data-range-includes="{{ property.rangeIncludes | replace: 'https://schema.org/', '' | escape }}"
+          data-sub-property-of="{{ property.subPropertyOf | replace: 'https://schema.org/', '' | escape }}"
+          data-inverse-of="{{ property.inverseOf | replace: 'https://schema.org/', '' | escape }}">
         <td>
           <a href="https://schema.org/{{ property.label }}" class="schema-link">{{ property.label }}</a>
         </td>
@@ -2326,7 +2333,11 @@ The Japanese manual includes a translated copy of the draft. Use the official IE
   </thead>
   <tbody>
     {% for type in site.data.schema_types %}
-      <tr>
+      <tr id="schema-type-{{ type.label }}"
+          data-schema-term="{{ type.label | escape }}"
+          data-schema-kind="type"
+          data-sub-type-of="{{ type.subTypeOf | replace: 'https://schema.org/', '' | escape }}"
+          data-properties="{{ type.properties | replace: 'https://schema.org/', '' | escape }}">
         <td>
           <a href="https://schema.org/{{ type.label }}" class="schema-link">{{ type.label }}</a>
         </td>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2284,7 +2284,7 @@ The Japanese manual includes a translated copy of the draft. Use the official IE
 
 <!-- Source: manuals/1.0/en/schema-org.md -->
 
-<link rel="stylesheet" href="{{ '/css/schema-styles.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/css/schema-styles.css' | relative_url }}?v=20260612">
 <script src="{{ '/js/schema-xref.js' | relative_url }}" defer></script>
 
 

--- a/manuals/1.0/en/schema-org.md
+++ b/manuals/1.0/en/schema-org.md
@@ -7,6 +7,7 @@ permalink: /manuals/1.0/en/schema-org.html
 ---
 
 <link rel="stylesheet" href="{{ '/css/schema-styles.css' | relative_url }}">
+<script src="{{ '/js/schema-xref.js' | relative_url }}" defer></script>
 
 
 # Schema.org Terms
@@ -25,7 +26,13 @@ permalink: /manuals/1.0/en/schema-org.html
   </thead>
   <tbody>
     {% for property in site.data.schema_properties %}
-      <tr>
+      <tr id="schema-property-{{ property.label }}"
+          data-schema-term="{{ property.label | escape }}"
+          data-schema-kind="property"
+          data-domain-includes="{{ property.domainIncludes | replace: 'https://schema.org/', '' | escape }}"
+          data-range-includes="{{ property.rangeIncludes | replace: 'https://schema.org/', '' | escape }}"
+          data-sub-property-of="{{ property.subPropertyOf | replace: 'https://schema.org/', '' | escape }}"
+          data-inverse-of="{{ property.inverseOf | replace: 'https://schema.org/', '' | escape }}">
         <td>
           <a href="https://schema.org/{{ property.label }}" class="schema-link">{{ property.label }}</a>
         </td>
@@ -48,7 +55,11 @@ permalink: /manuals/1.0/en/schema-org.html
   </thead>
   <tbody>
     {% for type in site.data.schema_types %}
-      <tr>
+      <tr id="schema-type-{{ type.label }}"
+          data-schema-term="{{ type.label | escape }}"
+          data-schema-kind="type"
+          data-sub-type-of="{{ type.subTypeOf | replace: 'https://schema.org/', '' | escape }}"
+          data-properties="{{ type.properties | replace: 'https://schema.org/', '' | escape }}">
         <td>
           <a href="https://schema.org/{{ type.label }}" class="schema-link">{{ type.label }}</a>
         </td>

--- a/manuals/1.0/en/schema-org.md
+++ b/manuals/1.0/en/schema-org.md
@@ -6,7 +6,7 @@ sidebar: false
 permalink: /manuals/1.0/en/schema-org.html
 ---
 
-<link rel="stylesheet" href="{{ '/css/schema-styles.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/css/schema-styles.css' | relative_url }}?v=20260612">
 <script src="{{ '/js/schema-xref.js' | relative_url }}" defer></script>
 
 

--- a/manuals/1.0/ja/schema-org.md
+++ b/manuals/1.0/ja/schema-org.md
@@ -7,6 +7,7 @@ permalink: /manuals/1.0/ja/schema-org.html
 ---
 
 <link rel="stylesheet" href="{{ '/css/schema-styles.css' | relative_url }}">
+<script src="{{ '/js/schema-xref.js' | relative_url }}" defer></script>
 
 
 # Schema.org 用語集
@@ -25,7 +26,13 @@ permalink: /manuals/1.0/ja/schema-org.html
   </thead>
   <tbody>
     {% for property in site.data.schema_properties_ja %}
-      <tr>
+      <tr id="schema-property-{{ property.label }}"
+          data-schema-term="{{ property.label | escape }}"
+          data-schema-kind="property"
+          data-domain-includes="{{ property.domainIncludes | replace: 'https://schema.org/', '' | escape }}"
+          data-range-includes="{{ property.rangeIncludes | replace: 'https://schema.org/', '' | escape }}"
+          data-sub-property-of="{{ property.subPropertyOf | replace: 'https://schema.org/', '' | escape }}"
+          data-inverse-of="{{ property.inverseOf | replace: 'https://schema.org/', '' | escape }}">
         <td>
           <a href="https://schema.org/{{ property.label }}" class="schema-link">{{ property.label }}</a>
         </td>
@@ -48,7 +55,11 @@ permalink: /manuals/1.0/ja/schema-org.html
   </thead>
   <tbody>
     {% for type in site.data.schema_types_ja %}
-      <tr>
+      <tr id="schema-type-{{ type.label }}"
+          data-schema-term="{{ type.label | escape }}"
+          data-schema-kind="type"
+          data-sub-type-of="{{ type.subTypeOf | replace: 'https://schema.org/', '' | escape }}"
+          data-properties="{{ type.properties | replace: 'https://schema.org/', '' | escape }}">
         <td>
           <a href="https://schema.org/{{ type.label }}" class="schema-link">{{ type.label }}</a>
         </td>

--- a/manuals/1.0/ja/schema-org.md
+++ b/manuals/1.0/ja/schema-org.md
@@ -6,7 +6,7 @@ sidebar: false
 permalink: /manuals/1.0/ja/schema-org.html
 ---
 
-<link rel="stylesheet" href="{{ '/css/schema-styles.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/css/schema-styles.css' | relative_url }}?v=20260612">
 <script src="{{ '/js/schema-xref.js' | relative_url }}" defer></script>
 
 


### PR DESCRIPTION
## Summary
- add clickable schema.org term cross references for properties and types
- show the first Used by entries inline, with the remaining references available via expansion
- add internal anchors and styling for linked rows

## Validation
- node --check js/schema-xref.js
- bundle exec jekyll build --destination /private/tmp/alps-asd-site
- visually checked the generated English and Japanese schema.org pages in the in-app browser
